### PR TITLE
Add the solutions for the exercises in section 1.1

### DIFF
--- a/solutions-rait/README.md
+++ b/solutions-rait/README.md
@@ -1,0 +1,7 @@
+# SICP solutions - Rait
+
+This directory will contain my solutions to the SICP exercises. Currently I am trying out 
+the Jupyter Notebook using the IRacket kernel [1] for doing the exercises, will see if I stick
+with it.
+
+1. https://github.com/rmculpepper/iracket

--- a/solutions-rait/ch01/ch01_1.ipynb
+++ b/solutions-rait/ch01/ch01_1.ipynb
@@ -1,0 +1,846 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5ccc77b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#lang iracket/lang #:require sicp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e797c1f1",
+   "metadata": {},
+   "source": [
+    "# Chapter 1\n",
+    "\n",
+    "## 1.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a74b4970",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>10</code>"
+      ],
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "10\n",
+    "; 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b8c1115b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>12</code>"
+      ],
+      "text/plain": [
+       "12"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(+ 5 3 4)\n",
+    "; 12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e49f9f62",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>8</code>"
+      ],
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(- 9 1)\n",
+    "; 8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0fbbff4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>3</code>"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(/ 6 2)\n",
+    "; 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "404916c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>6</code>"
+      ],
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(+ (* 2 4) (- 4 6))\n",
+    "; 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "efdcee05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define a 3)\n",
+    ";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ca0b431b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define b (+ a 1))\n",
+    ";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6aa22e08",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>19</code>"
+      ],
+      "text/plain": [
+       "19"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(+ a b (* a b))\n",
+    "; 19"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "be67cc3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>#f</code>"
+      ],
+      "text/plain": [
+       "#f"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(= a b)\n",
+    "; #f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "aaa7fb44",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>4</code>"
+      ],
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(if (and (> b a) (< b (* a b)))\n",
+    "    b\n",
+    "    a)\n",
+    "; 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "fa8b1d5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>16</code>"
+      ],
+      "text/plain": [
+       "16"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(cond ((= a 4) 6)\n",
+    "      ((= b 4) (+ 6 7 a))\n",
+    "      (else 25))\n",
+    "; 16"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "d5361524",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>6</code>"
+      ],
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(+ 2 (if (> b a) b a))\n",
+    "; 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "34a274f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>16</code>"
+      ],
+      "text/plain": [
+       "16"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(* (cond ((> a b) a)\n",
+    "         ((< a b) b)\n",
+    "         (else -1))\n",
+    "   (+ a 1))\n",
+    "; 16"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "765e800e",
+   "metadata": {},
+   "source": [
+    "## 1.2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "43b329a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>-37/150</code>"
+      ],
+      "text/plain": [
+       "-37/150"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(/ (+ 5 \n",
+    "      4 \n",
+    "      (- 2 (- 3 (+ 6 (/ 4 5)))))\n",
+    "   (* 3 \n",
+    "      (- 6 2) \n",
+    "      (- 2 7)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cf6aba6",
+   "metadata": {},
+   "source": [
+    "## 1.3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "216b53d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define (square x) (* x x))\n",
+    "\n",
+    "(define (sum-of-squares a b)\n",
+    "  (+ (square a) (square b)))\n",
+    "\n",
+    "(define (larger-of-two a b)\n",
+    "  (if (> a b) \n",
+    "      a \n",
+    "      b))\n",
+    "\n",
+    "(define (sum-of-squares-of-two-largest a b c)\n",
+    "  (if (> a b) \n",
+    "      (sum-of-squares a (larger-of-two b c))\n",
+    "      (sum-of-squares b (larger-of-two a c))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "944d27f2",
+   "metadata": {},
+   "source": [
+    "### Tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "741fae64",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>41</code>"
+      ],
+      "text/plain": [
+       "41"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(sum-of-squares-of-two-largest 4 2 5)\n",
+    "; 4 * 4 + 5 * 5 = 16 + 25 = 41"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "aad47315",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>13</code>"
+      ],
+      "text/plain": [
+       "13"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(sum-of-squares-of-two-largest 3 2 1)\n",
+    "; 3 * 3 + 2 * 2 = 9 + 4 = 13"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "cd007ae7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>149</code>"
+      ],
+      "text/plain": [
+       "149"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(sum-of-squares-of-two-largest 6 10 7)\n",
+    "; 10 * 10 + 7 * 7 = 100 + 49 = 149"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "674266d1",
+   "metadata": {},
+   "source": [
+    "## 1.4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "51a9cf67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define (a-plus-abs-b a b)\n",
+    "  ((if (> b 0) + -) a b))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c52be8b1",
+   "metadata": {},
+   "source": [
+    "The above function performs _a + |b|_\n",
+    "\n",
+    "It evaluates a conditional statement to determine whether to use the operator + or - for the function. The if-conditional evaluates `(> b 0)`and returns + for `#t` and - otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "290664b0",
+   "metadata": {},
+   "source": [
+    "## 1.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17d9cbd1",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "(define (p) (p))\n",
+    "\n",
+    "(define (test x y)\n",
+    "  (if (= x 0)\n",
+    "      0\n",
+    "      y))\n",
+    "\n",
+    "(test 0 (p))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26f1a1b8",
+   "metadata": {},
+   "source": [
+    "In applicative-order evaluation, this test would stall forever as it would be trying to evaluate all the operands first. Function `p` calls itself and never exits.\n",
+    "\n",
+    "In normal order evaluation, it would fully expand the function until only primitive operators remain and only then reduce the required operands. This would return 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "503fa644",
+   "metadata": {},
+   "source": [
+    "## 1.6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "417784ad",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "(define (sqrt-iter guess x)\n",
+    "  (new-if (good-enough? guess x)\n",
+    "          guess\n",
+    "          (sqrt-iter (improve guess x)\n",
+    "                     x)))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a2fbf6b",
+   "metadata": {},
+   "source": [
+    "If Alyssa attempts to run the above code for calculating a square root, it will get stuck in an infinite recursive loop and never terminate. The reasoning for this is that the built-in `if` is a special form that evaluates differently from normal procedures - it evaluates the predicate and then evaluates the corresponding consequent expression. \n",
+    "\n",
+    "However, the `new-if` procedure obeys the standard rules of applicative-order evaluation by first evaluating all the operands. Since the last operand is another call to `sqrt-iter`, it will start a new procedure call and it will keep looping forever."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9e43a61",
+   "metadata": {},
+   "source": [
+    "## 1.7"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "aa372cb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define (square x) (* x x))\n",
+    "\n",
+    "(define (good-enough? guess x)\n",
+    "  (< (abs (- (square guess) x)) 0.001))\n",
+    "\n",
+    "(define (average x y)\n",
+    "  (/ (+ x y) 2))\n",
+    "\n",
+    "(define (improve guess x)\n",
+    "  (average guess (/ x guess)))\n",
+    "\n",
+    "(define (sqrt-iter guess x)\n",
+    "  (if (good-enough? guess x)\n",
+    "      guess\n",
+    "      (sqrt-iter (improve guess x)\n",
+    "                 x)))\n",
+    "\n",
+    "(define (sqrt x)\n",
+    "  (sqrt-iter 1.0 x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c0e0fed",
+   "metadata": {},
+   "source": [
+    "For very small numbers, the `good-enough?` check provided by the book is inadequate for really small numbers because the allowed difference is too high.\n",
+    "\n",
+    "For example, consider taking the square root of 0.0001:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "27ffae7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>0.03230844833048122</code>"
+      ],
+      "text/plain": [
+       "0.03230844833048122"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(sqrt 0.0001)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d00aa58c",
+   "metadata": {},
+   "source": [
+    "The true square root of 0.0001 is 0.01 however we receive the answer 0.0323. The `good-enough?` procedure takes the square of 0.0323, which is roughly 0.00104, subtracts the radicand from it and checks if the absolute value (0.00104 - 0.001 = 0.00004) is within our error tolerance of 0.001, but our error tolerance is too high to deal with such small numbers.\n",
+    "\n",
+    "For large numbers, having the error tolerance be at 0.001 will mean that for sufficiently large numbers, the program will usually never terminate. Due to how floating point numbers work, we run out of precision and the rounding errors make consecutive numbers have a larger gap than 0.001.\n",
+    "\n",
+    "\"An alternative strategy for implementing good-enough? is to watch how guess changes from one iteration to the next and to stop when the change is a very small fraction of the guess. Design a square-root procedure that uses this kind of end test. Does this work better for small and large numbers?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "0348643f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define (new-good-enough? prev-guess guess)\n",
+    "  (< (abs (- guess prev-guess)) 0.00000000001))\n",
+    "\n",
+    "(define (new-sqrt-iter guess x)\n",
+    "  (if (new-good-enough? guess (improve guess x))\n",
+    "      guess\n",
+    "      (new-sqrt-iter (improve guess x)\n",
+    "                 x)))\n",
+    "\n",
+    "(define (new-sqrt x)\n",
+    "  (new-sqrt-iter 1.0 x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "fe2ec8be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>11111111.061111081</code>"
+      ],
+      "text/plain": [
+       "11111111.061111081"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(new-sqrt 123456789012345)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "c69a2e9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>0.01</code>"
+      ],
+      "text/plain": [
+       "0.01"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(new-sqrt 0.0001)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3c4cf67",
+   "metadata": {},
+   "source": [
+    "## 1.8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "09937f27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(define (improve guess x)\n",
+    "  (/ (+ (/ x (square guess))\n",
+    "        (* 2 guess))\n",
+    "     3))\n",
+    "\n",
+    "(define (cube-root-iter guess x)\n",
+    "  (if (new-good-enough? guess (improve guess x))\n",
+    "      guess\n",
+    "      (cube-root-iter (improve guess x)\n",
+    "                      x)))\n",
+    "\n",
+    "(define (cube-root x) (cube-root-iter 1.0 x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "3528b30d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>9.0</code>"
+      ],
+      "text/plain": [
+       "9.0"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(cube-root 729)\n",
+    "; cube of 9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "a600a102",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>5.0</code>"
+      ],
+      "text/plain": [
+       "5.0"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(cube-root 125)\n",
+    "; cube of 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "dd440e28",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<code>5.500000000000007</code>"
+      ],
+      "text/plain": [
+       "5.500000000000007"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(cube-root 166.375)\n",
+    "; cube of 5.5"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Racket",
+   "language": "racket",
+   "name": "racket"
+  },
+  "language_info": {
+   "codemirror_mode": "scheme",
+   "file_extension": ".rkt",
+   "mimetype": "text/x-racket",
+   "name": "Racket",
+   "pygments_lexer": "racket",
+   "version": "8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I've created a `solutions-rait` directory which has a Jupyter Notebook file using the IRacket kernel containing my solutions for the exercises in section 1.1

Direct link to looking at the notebook through GitHub: https://github.com/e-lambda/SICP-summer-2023/blob/rait-week1/solutions-rait/ch01/ch01_1.ipynb